### PR TITLE
acceptance: prefer script dirname to static path

### DIFF
--- a/tests/acceptance/debug.sh
+++ b/tests/acceptance/debug.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd tests/acceptance
+cd "$( dirname "${BASH_SOURCE[0]}" )"
 
 docker-compose build
 RESULT=$?

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd tests/acceptance
+cd "$( dirname "${BASH_SOURCE[0]}" )"
 
 docker-compose build
 RESULT=$?


### PR DESCRIPTION
This improves resiliency should the scripts or callers be moved.