### PR TITLE
Fix Travis builds

### DIFF
--- a/tests/acceptance/docker-compose.base.yml
+++ b/tests/acceptance/docker-compose.base.yml
@@ -14,7 +14,7 @@ services:
       - ./screenshots:/usr/src/app/tests/acceptance/screenshots
 
   selenium:
-    image: selenium/hub:3.4.0
+    image: selenium/hub:3.4.0-chromium
     expose:
       - '4444'
     ports:
@@ -25,10 +25,10 @@ services:
       - /dev/urandom:/dev/random
 
   chrome:
-    image: selenium/node-chrome:3.4.0
+    image: selenium/node-chrome:3.4.0-chromium
 
   firefox:
-    image: selenium/node-firefox:3.4.0
+    image: selenium/node-firefox:3.4.0-chromium
 
   debug_node:
-    image: "selenium/node-${BROWSER:-chrome}-debug:3.4.0"
+    image: "selenium/node-${BROWSER:-chrome}-debug:3.4.0-chromium"


### PR DESCRIPTION
Apparently numbered tags get updated. Seems like suffixed tags don't so I'm
pinning the last one that worked (chromium). dysprosium has been released 20
hours ago and there's some small differences in how the checkboxes are rendered
(seems like different aliasing). Not going to update to that now as the changes
in the screenshots are small and it doesn't seem worth upgrading.

![image](https://user-images.githubusercontent.com/485061/27003501-146e0a3a-4df8-11e7-819c-a5f983178860.png)

Closes #99.
Closes #98.