### PR TITLE
Upgrade Cosmos and simplify config

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "mugshot-webdriverio": "~1.0.0",
     "normalize.css": "~7.0.0",
     "nyc": "~11.1.0",
-    "react-cosmos-webpack": "~2.0.0-beta.11",
+    "react-cosmos-webpack": "~2.0.0-beta.23",
     "react-hot-loader": "~3.0.0-beta.6",
     "rosie": "~1.6.0",
     "sinon": "~3.2.0",

--- a/playground/cosmos.config.js
+++ b/playground/cosmos.config.js
@@ -4,7 +4,5 @@ module.exports = {
   fixturePaths: ['./fixtures'],
   // TODO: remove this and have every component depend on it
   // https://github.com/react-cosmos/react-cosmos/pull/364
-  globalImports: ['../src/index.less'],
-  publicPath: './',
-  hmrPlugin: false
+  globalImports: ['../src/index.less']
 };


### PR DESCRIPTION
- publicPath wasn't used
- hmrPlugin is no longer needed, Cosmos [detects automatically](https://github.com/react-cosmos/react-cosmos/blob/299fc740426ac08b8dcdb31017fb84a1b0e3ec40/packages/react-cosmos-webpack/src/loader-webpack-config.js#L5-L9) if user webpack config already has it or not