### PR TITLE
Generate coverage reports from acceptance tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -19,11 +19,6 @@
       "plugins": [
         "react-hot-loader/babel"
       ]
-    },
-    "tests": {
-      "plugins": [
-        "istanbul"
-      ]
     }
   }
 }

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -23,5 +23,5 @@
 
   "lines": 100,
   "branches": 100,
-  "check-coverage": true
+  "check-coverage": false
 }

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -19,7 +19,7 @@
   ],
 
   "reporter": ["html"],
-  "report-dir": "tests/unit/results/coverage",
+  "report-dir": "tests/results/coverage",
 
   "lines": 100,
   "branches": 100,

--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ debugging in Node with the node inspector.
 
 ![coverage](./docs/coverage.png)
 
-The unit tests automatically generate coverage reports using `Istanbul`. You can
-find them in the
-[tests/unit/results/coverage](./tests/unit/results/coverage/index.html) folder.
+The tests automatically generate coverage reports using `Istanbul`. You can find
+them in the [tests/results/coverage](./tests/results/coverage/index.html)
+folder. **Both unit tests and acceptance tests report coverage** which allows
+reaching 100% coverage for those cases where unit tests are not enough (scroll
+event handlers, browser quirks, etc.).
 
 
 # Acceptance tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,5 @@ services:
   app:
     build: ./
     command: npm run _start
+    environment:
+      - NODE_ENV

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Andrei Picus",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:unit --silent && npm run test:acceptance --silent",
+    "test": "./tests/run.sh",
     "test:unit": "NODE_ENV=tests nyc npm run _mocha",
     "test:unit:watch": "npm run _mocha -- --compilers js:babel-register --watch --watch-extensions js,jsx --reporter min",
     "_mocha": "mocha tests/unit/helpers/index.node.js 'tests/unit/**/*.spec.js'",

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,0 +1,11 @@
+{
+  "extends": "../.babelrc",
+
+  "env": {
+    "tests": {
+      "plugins": [
+        "istanbul"
+      ]
+    }
+  }
+}

--- a/tests/acceptance/docker-compose.base.yml
+++ b/tests/acceptance/docker-compose.base.yml
@@ -12,6 +12,7 @@ services:
       - '3000'
     volumes:
       - ./screenshots:/usr/src/app/tests/acceptance/screenshots
+      - ./results/coverage:/usr/src/app/tests/acceptance/results/coverage
 
   selenium:
     image: selenium/hub:3.4.0-chromium

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -9,6 +9,8 @@ set -e
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 
+export NODE_ENV=tests
+
 docker-compose build
 
 # If we don't create these here, docker-compose will and they will be owned by

--- a/tests/acceptance/setup.js
+++ b/tests/acceptance/setup.js
@@ -2,6 +2,7 @@ import { remote } from 'webdriverio';
 import Mugshot from 'mugshot';
 import WebdriverIOAdapter from 'mugshot-webdriverio';
 import path from 'path';
+import fs from 'fs';
 
 
 const { BROWSER } = process.env;
@@ -71,6 +72,19 @@ afterEach(function() {
 
   // eslint-disable-next-line consistent-return
   return checkForVisualChanges(this.test, this.currentTest.fullTitle());
+});
+
+afterEach('coverage', async function() {
+  const { value: coverage } = await browser.execute(function getCoverage() {
+    return JSON.stringify(window.__coverage__);
+  });
+
+  const name = this.currentTest.fullTitle();
+
+  fs.writeFileSync(
+    path.join(__dirname, 'results', 'coverage', `${BROWSER}_${name}.json`),
+    coverage
+  );
 });
 
 

--- a/tests/coverage.js
+++ b/tests/coverage.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..');
+const coverageDir = path.join(rootDir, '.nyc_output');
+const files = fs.readdirSync(coverageDir);
+
+// Coverage reports from inside the container will have a base path from the
+// container so we need to replace it with the correct path from the host.
+files.forEach(file => {
+  const filePath = path.join(coverageDir, file);
+  const content = fs.readFileSync(filePath, { encoding: 'utf8' });
+
+  fs.writeFileSync(
+    filePath,
+    // Make sure to preserve the trailing separator.
+    content.replace(/\/usr\/src\/app/g, rootDir)
+  );
+});

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+rm -rf ./acceptance/results/coverage
+mkdir -p ./acceptance/results/coverage
+
+npm run test:unit --silent
+npm run test:acceptance --silent
+
+cp ./acceptance/results/coverage/*.json ../.nyc_output/
+./coverage.js
+
+# nyc will create the report relative to cwd so we need to be in root.
+cd ..
+
+node_modules/.bin/nyc report
+node_modules/.bin/nyc check-coverage


### PR DESCRIPTION
This allows reaching 100% coverage for those cases where unit tests are not enough (scroll event handlers, browser quirks, etc.).